### PR TITLE
api routes framework

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,14 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
-  resources :decks do
-    resources :flashcards
+  namespace :api do
+    namespace :v1 do
+      # define routes for API requests here
+    end
   end
 end
+
+root '/'
+
+# do we need a fallback like this?
+# get '/*path' => 'decks#index'


### PR DESCRIPTION
Removed the `resources do` routes since I think we define those routes within routes/index.jsx (and not all flashcards routes should be nested inside decks btw)